### PR TITLE
Add timing harnesses without encoding and extend extract.py features

### DIFF
--- a/dilithium-py/timing_no_encode.py
+++ b/dilithium-py/timing_no_encode.py
@@ -1,0 +1,147 @@
+"""
+Measure ML-DSA signing times of dilithium-py (excluding _pack_sig) .
+"""
+import argparse
+import sys
+import time
+from pathlib import Path
+from dilithium_py.ml_dsa.ml_dsa import ML_DSA
+from dilithium_py.ml_dsa.default_parameters import DEFAULT_PARAMETERS
+from dilithium_py.ml_dsa.pkcs import sk_from_pem
+
+
+SCHEMES = {
+    "mldsa-44": DEFAULT_PARAMETERS["ML_DSA_44"],
+    "mldsa-65": DEFAULT_PARAMETERS["ML_DSA_65"],
+    "mldsa-87": DEFAULT_PARAMETERS["ML_DSA_87"]
+}
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Measure ML-DSA signing times of dilithium-py"
+    )
+    parser.add_argument(
+        "--input", "-i", 
+        type=str, 
+        required=True,
+        help="Input file containing messages to sign"
+    )
+    parser.add_argument(
+        "--output", "-o", 
+        type=str, 
+        default=None,
+        help="File to write signatures to "
+        "(default: {scheme}/results/signatures.bin)"
+    )
+    parser.add_argument(
+        "--timings", "-t", 
+        type=str, 
+        default=None,
+        help="File to write timings to "
+        "(default: {scheme}/results/timings.csv)"
+    ) 
+    parser.add_argument(
+        "--scheme", "-s", 
+        type=str, 
+        required=True,
+        choices=["mldsa-44", "mldsa-65", "mldsa-87"],
+        help="ML-DSA scheme to use"
+    )                 
+    parser.add_argument(
+        "--key", "-k", 
+        type=str, 
+        default=None,
+        help="Path to private key file "
+        "(default: {scheme}/keys/sk.pem)"
+    )
+    parser.add_argument(
+        "--size", 
+        type=int, 
+        default=32,
+        help="Size of messages to sign"
+    )
+    parser.add_argument(
+        "--samples", "-n", 
+        type=int, 
+        default=None,
+        help="Number of messages to sign"
+    )
+
+    return parser.parse_args()
+
+def load_private_key(key_path: Path):
+    file_content = key_path.read_bytes()
+    ml_dsa, sk, _, _ = sk_from_pem(file_content)
+    return ml_dsa, sk
+    
+
+def main():
+    args = parse_args()
+
+    scheme_name = args.scheme
+    params = SCHEMES[scheme_name]
+    input_path = Path(args.input)
+
+    if args.key:
+        key_path = Path(args.key)
+    else:
+        key_path = Path(scheme_name) / "keys" / "sk.pem"
+    
+    if not key_path.exists():
+        print(f"Error: Private key file {key_path} not found")
+        sys.exit(1)
+    
+    result_dir = Path(scheme_name) / "results"
+    result_dir.mkdir(parents=True, exist_ok=True)
+    
+    if args.output:
+        output_path = Path(args.output)
+    else:
+        output_path = result_dir / "signatures.bin"
+    
+    if args.timings:
+        timings_path = Path(args.timings)
+    else:
+        timings_path = result_dir / "timings.csv"
+    
+    ml_dsa, sk = load_private_key(key_path)
+    scheme = ml_dsa
+
+    block_size = args.size
+    samples = args.samples
+    if samples is None:
+        file_size = input_path.stat().st_size
+        samples = file_size // block_size
+
+    print(f"Starting timing measurements for {scheme_name}")
+    print(f"Reading messages from {input_path}")
+    print(f"Writing signatures to {output_path}")
+    print(f"Writing timing data to {timings_path}")
+    print(f"Processing {samples} messages of {block_size} bytes each")
+
+    with open(input_path, "rb") as in_fp, \
+         open(output_path, "wb") as sig_fp, \
+         open(timings_path, "w") as time_fp:
+         time_fp.write("raw_times\n")
+
+
+         for i in range(samples):
+            data = in_fp.read(block_size)
+            if not data or len(data) != block_size:
+                break
+
+            sig = scheme.sign(sk, data, deterministic=True)
+
+            time_diff = scheme._last_time
+
+            time_fp.write("{0}\n".format(time_diff))
+            sig_fp.write(sig)
+
+            if (i+1) % 1000 == 0:
+                print(f"Processed {i+1}/{samples}")
+
+    print("Done.")
+
+if __name__ == "__main__":
+    main()
+    

--- a/extract.py
+++ b/extract.py
@@ -2157,6 +2157,42 @@ class Extract:
                             c -= q
                     yield int(c)
 
+    def _vector_coeff_stats(self, vector, q, alpha=None):
+        """
+        For a polynomial vector in coefficient domain, compute:
+        - n_zero: number of coefficients equal to 0
+        - n_need_reduction: number of coefficients outside [-q/2, q/2) (would need modular reduction)
+        - n_fully_low_bit / n_above_low_bit_cutoff: (if alpha) split by |c| <= alpha//2.
+        """
+        n_zero = 0
+        n_need_reduction = 0
+        n_fully_low_bit = 0
+        n_above_low_bit_cutoff = 0
+        half_q = q // 2
+        alpha_half = (alpha // 2) if alpha is not None else None
+
+        for c in self._iter_vector_coeffs(vector, centered=False):
+            c = int(c)
+            if c == 0:
+                n_zero += 1
+            c_red = c % q
+            if c_red > half_q:
+                c_red -= q
+            if c != c_red:
+                n_need_reduction += 1
+            if alpha_half is not None:
+                ac = abs(c)
+                if ac <= alpha_half:
+                    n_fully_low_bit += 1
+                else:
+                    n_above_low_bit_cutoff += 1
+
+        out = {"n_zero": n_zero, "n_need_reduction": n_need_reduction}
+        if alpha is not None:
+            out["n_fully_low_bit"] = n_fully_low_bit
+            out["n_above_low_bit_cutoff"] = n_above_low_bit_cutoff
+        return out
+
     def _prepare_ml_dsa_context(self, scheme, sk):
         rho, k, tr, s1, s2, t0 = scheme._unpack_sk(sk)
 
@@ -2221,32 +2257,33 @@ class Extract:
         # r0 = low_bits(w-cs2)
         c_s2_hat = s2_hat.scale(c_hat)
         c_s2 = c_s2_hat.from_ntt()
-        r0 = (w-c_s2).low_bits(alpha)
+
+        w0 = w.low_bits(alpha)
 
         # === Features ===
         if rho_prime is not None:
             values["hw-rho-prime"] = bit_count(bytesToNumber(rho_prime))
             values["bit-size-rho-prime"] = bit_length(bytesToNumber(rho_prime))
-        
+            values["rho-prime-n-zero"] = sum(1 for b in rho_prime if b == 0)
+
         # y coeff domain
         y_hw = 0
         y_bits = 0
-        y_inf = 0
         for c0 in self._iter_vector_coeffs(y):
-            ac = abs(c0)
             y_hw += bit_count(c0)
             y_bits += bit_length(c0)
-            if ac > y_inf:
-                y_inf = ac
         values["hw-y"] = y_hw
         values["bit-size-y"] = y_bits
-        values["inf-norm-y"] = y_inf
+        sy = self._vector_coeff_stats(y, q, alpha)
+        values["y-n-zero"] = sy["n_zero"]
+        values["y-n-need-reduction"] = sy["n_need_reduction"]
+        values["y-n-fully-low-bit"] = sy["n_fully_low_bit"]
+        values["y-n-above-low-bit-cutoff"] = sy["n_above_low_bit_cutoff"]
 
         # y NTT domain
         y_ntt_hw = 0
         y_ntt_bits = 0
         for c0 in self._iter_vector_coeffs(y_hat):
-            ac = abs(c0)
             y_ntt_hw += bit_count(c0)
             y_ntt_bits += bit_length(c0)
         values["ntt-hw-y"] = y_ntt_hw
@@ -2256,17 +2293,20 @@ class Extract:
         w_hw = 0
         w_bits = 0
         for c0 in self._iter_vector_coeffs(w):
-            ac = abs(c0)
             w_hw += bit_count(c0)
             w_bits += bit_length(c0)
         values["hw-w"] = w_hw
         values["bit-size-w"] = w_bits
+        sw = self._vector_coeff_stats(w, q, alpha)
+        values["w-n-zero"] = sw["n_zero"]
+        values["w-n-need-reduction"] = sw["n_need_reduction"]
+        values["w-n-fully-low-bit"] = sw["n_fully_low_bit"]
+        values["w-n-above-low-bit-cutoff"] = sw["n_above_low_bit_cutoff"]
 
         # w NTT domain
         w_ntt_hw = 0
         w_ntt_bits = 0
         for c0 in self._iter_vector_coeffs(w_hat):
-            ac = abs(c0)
             w_ntt_hw += bit_count(c0)
             w_ntt_bits += bit_length(c0)
         values["ntt-hw-w"] = w_ntt_hw
@@ -2276,16 +2316,17 @@ class Extract:
         cs1_hw = 0
         cs1_bits = 0
         for c0 in self._iter_vector_coeffs(c_s1):
-            ac = abs(c0)
             cs1_hw += bit_count(c0)
             cs1_bits += bit_length(c0)
         values["hw-c-s1"] = cs1_hw
         values["bit-size-c-s1"] = cs1_bits
+        scs1 = self._vector_coeff_stats(c_s1, q)
+        values["c-s1-n-zero"] = scs1["n_zero"]
+        values["c-s1-n-need-reduction"] = scs1["n_need_reduction"]
 
         cs1_ntt_hw = 0
         cs1_ntt_bits = 0
         for c0 in self._iter_vector_coeffs(c_s1_hat):
-            ac = abs(c0)
             cs1_ntt_hw += bit_count(c0)
             cs1_ntt_bits += bit_length(c0)
         values["ntt-hw-c-s1"] = cs1_ntt_hw
@@ -2295,34 +2336,29 @@ class Extract:
         cs2_hw = 0
         cs2_bits = 0
         for c0 in self._iter_vector_coeffs(c_s2):
-            ac = abs(c0)
             cs2_hw += bit_count(c0)
             cs2_bits += bit_length(c0)
         values["hw-c-s2"] = cs2_hw
         values["bit-size-c-s2"] = cs2_bits
+        scs2 = self._vector_coeff_stats(c_s2, q)
+        values["c-s2-n-zero"] = scs2["n_zero"]
+        values["c-s2-n-need-reduction"] = scs2["n_need_reduction"]
 
         cs2_ntt_hw = 0
         cs2_ntt_bits = 0
         for c0 in self._iter_vector_coeffs(c_s2_hat):
-            ac = abs(c0)
             cs2_ntt_hw += bit_count(c0)
             cs2_ntt_bits += bit_length(c0)
         values["ntt-hw-c-s2"] = cs2_ntt_hw
-        values["ntt-bit-size-c-s2"] = cs2_ntt_bits       
+        values["ntt-bit-size-c-s2"] = cs2_ntt_bits
 
-        # (w - c*s2).low_bits(alpha)
         w0_hw = 0
         w0_bits = 0
-        w0_inf = 0
-        for c0 in self._iter_vector_coeffs(r0):
-            ac = abs(c0)
+        for c0 in self._iter_vector_coeffs(w0):
             w0_hw += bit_count(c0)
             w0_bits += bit_length(c0)
-            if ac > w0_inf:
-                w0_inf = ac
-        values["hw-w-cs2-low-bits"] = w0_hw
-        values["bit-size-w-cs2-low-bits"] = w0_bits
-        values["inf-norm-w0"] = w0_inf
+        values["hw-w0"] = w0_hw
+        values["bit-size-w0"] = w0_bits
 
         return values
 
@@ -2342,26 +2378,37 @@ class Extract:
         value_names = {
             "hw-rho-prime": {"window": 17},
             "bit-size-rho-prime": {"window": 17},
+            "rho-prime-n-zero": {"window": 17},
             "hw-y": {"window": 30},
             "bit-size-y": {"window": 30},
+            "y-n-zero": {"window": 30},
+            "y-n-need-reduction": {"window": 30},
+            "y-n-fully-low-bit": {"window": 30},
+            "y-n-above-low-bit-cutoff": {"window": 30},
             "ntt-hw-y": {"window": 30},
             "ntt-bit-size-y": {"window": 30},
             "hw-w": {"window": 30},
             "bit-size-w": {"window": 30},
+            "w-n-zero": {"window": 30},
+            "w-n-need-reduction": {"window": 30},
+            "w-n-fully-low-bit": {"window": 30},
+            "w-n-above-low-bit-cutoff": {"window": 30},
             "ntt-hw-w": {"window": 30},
             "ntt-bit-size-w": {"window": 30},
             "hw-c-s1": {"window": 30},
             "bit-size-c-s1": {"window": 30},
+            "c-s1-n-zero": {"window": 30},
+            "c-s1-n-need-reduction": {"window": 30},
             "ntt-hw-c-s1": {"window": 30},
             "ntt-bit-size-c-s1": {"window": 30},
             "hw-c-s2": {"window": 30},
             "bit-size-c-s2": {"window": 30},
+            "c-s2-n-zero": {"window": 30},
+            "c-s2-n-need-reduction": {"window": 30},
             "ntt-hw-c-s2": {"window": 30},
             "ntt-bit-size-c-s2": {"window": 30},
-            "hw-w-cs2-low-bits": {"window": 30},
-            "bit-size-w-cs2-low-bits": {"window": 30},
-            "inf-norm-y": {"window": 5},
-            "inf-norm-w0": {"window": 5},
+            "hw-w0": {"window": 30},
+            "bit-size-w0": {"window": 30},
         }
 
         try:

--- a/golang/key_timing.go
+++ b/golang/key_timing.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"time"
+	"unsafe"
+
+	// We need to import unsafe to use go:linkname, effectively telling the compiler
+	// we know what we are doing.
+	_ "unsafe"
+)
+
+// --- Linkname Definitions ---
+
+// We treat the private key as an opaque pointer (unsafe.Pointer) because
+// we cannot import the actual mldsa.PrivateKey struct definition.
+
+//go:linkname newPrivateKey44 crypto/internal/fips140/mldsa.NewPrivateKey44
+func newPrivateKey44(b []byte) (unsafe.Pointer, error)
+
+//go:linkname sign crypto/internal/fips140/mldsa.Sign
+func sign(priv unsafe.Pointer, msg []byte, context []byte) ([]byte, error)
+
+// ----------------------------
+
+func helpMsg() {
+	fmt.Println(`
+timing.go -i file -o file -k file -n size
+
+-i file      File with the messages to sign (32 byte long)
+-o file      File to write the timing data to
+-k file      The private keys to use for signing
+-n size      Size of individual keys (2560 for ML-DSA-44)
+-h | --help  this message
+`)
+}
+
+func main() {
+	var (
+		inFile   string
+		outFile  string
+		keyFile  string
+		readSize int
+		help     bool
+	)
+
+	flag.StringVar(&inFile, "i", "", "File with the messages to sign")
+	flag.StringVar(&outFile, "o", "", "File to write the timing data to")
+	flag.StringVar(&keyFile, "k", "", "The private keys to use for signing")
+	flag.IntVar(&readSize, "n", 0, "Size of individual keys")
+	flag.BoolVar(&help, "h", false, "Show help")
+	flag.BoolVar(&help, "help", false, "Show help")
+
+	flag.Parse()
+
+	if help || (inFile == "" && outFile == "" && keyFile == "" && readSize == 0) {
+		helpMsg()
+		if help {
+			os.Exit(0)
+		}
+		os.Exit(1)
+	}
+
+	if inFile == "" {
+		fmt.Fprintln(os.Stderr, "ERROR: no input file specified (-i)")
+		os.Exit(1)
+	}
+	if outFile == "" {
+		fmt.Fprintln(os.Stderr, "ERROR: no output file specified (-o)")
+		os.Exit(1)
+	}
+	if keyFile == "" {
+		fmt.Fprintln(os.Stderr, "ERROR: no key file specified (-k)")
+		os.Exit(1)
+	}
+	if readSize == 0 {
+		fmt.Fprintln(os.Stderr, "ERROR: size of ciphertexts unspecified (-n)")
+		os.Exit(1)
+	}
+
+	kFile, err := os.Open(keyFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error opening key file: %v\n", err)
+		os.Exit(1)
+	}
+	defer kFile.Close()
+
+	iFile, err := os.Open(inFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error opening input file: %v\n", err)
+		os.Exit(1)
+	}
+	defer iFile.Close()
+
+	oFile, err := os.Create(outFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error creating output file: %v\n", err)
+		os.Exit(1)
+	}
+	defer oFile.Close()
+
+	writer := bufio.NewWriter(oFile)
+	defer writer.Flush()
+
+	writer.WriteString("raw times\n")
+
+	keyBuf := make([]byte, readSize)
+	msgBuf := make([]byte, 32)
+
+	for {
+		// Read private key bytes
+		_, err := io.ReadFull(kFile, keyBuf)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error reading key: %v\n", err)
+			break
+		}
+
+		// Read message bytes
+		_, err = io.ReadFull(iFile, msgBuf)
+		if err == io.EOF {
+			break
+		}
+		if err != nil && err != io.ErrUnexpectedEOF {
+			fmt.Fprintf(os.Stderr, "Error reading message: %v\n", err)
+			break
+		}
+
+		// Linkname Call: Parse the private key
+		// This calls crypto/internal/fips140/mldsa.NewPrivateKey44
+		privKeyPtr, err := newPrivateKey44(keyBuf)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error parsing private key: %v\n", err)
+			continue
+		}
+
+		start := time.Now()
+
+		// Linkname Call: Sign the message
+		// This calls crypto/internal/fips140/mldsa.Sign
+		// We pass the unsafe.Pointer we got from newPrivateKey44 directly.
+		_, err = sign(privKeyPtr, msgBuf, "")
+
+		diff := time.Since(start).Nanoseconds()
+
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error signing: %v\n", err)
+			continue
+		}
+
+		writer.WriteString(fmt.Sprintf("%d\n", diff))
+	}
+
+	fmt.Println("done")
+}

--- a/golang/timing_no_encode.go
+++ b/golang/timing_no_encode.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"time"
 )
 
 func helpMsg() {
@@ -129,9 +128,7 @@ func main() {
 			break
 		}
 
-		start := time.Now()
-		sig, err := mldsa.SignDeterministic(privKey, msgBuf, "")
-		diff := time.Since(start).Nanoseconds()
+		sig, diff, err := mldsa.SignDeterministic(privKey, msgBuf, "")
 
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error signing: %v\n", err)

--- a/nettle/timing_no_encode.c
+++ b/nettle/timing_no_encode.c
@@ -1,0 +1,246 @@
+#include <memory.h>
+#include <string.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <errno.h>
+#include <assert.h>
+
+#include <nettle/base64.h>
+#include <nettle/ml-dsa.h>
+
+#define DER_HEADER_SIZE 66
+
+static void help(const char *name) {
+    fprintf(stderr, "Usage: %s -i file -o file -t file -k file -n num [-h]\n", name);
+    fprintf(stderr, "\n");
+    fprintf(stderr, " -i file    File with concatenated messages to sign\n");
+    fprintf(stderr, " -o file    File where to write the signatures\n");
+    fprintf(stderr, " -t file    File where to write timing data\n");
+    fprintf(stderr, " -k file    File with the ML-DSA private key in PEM format\n");
+    fprintf(stderr, " -n num     Length of individual messages in bytes\n");
+    fprintf(stderr, " -s num     ML-DSA parameter set: 65 or 87 (default: 65)\n");
+    fprintf(stderr, " -h         This message\n");
+}
+
+typedef void sign_func (const uint8_t *key,
+                        size_t msg_len, const uint8_t *msg,
+                        size_t ctx_len, const uint8_t *ctx,
+                        void *random_ctx, nettle_random_func *random,
+                        uint8_t *signature);
+
+static void
+random_zero(void *ctx, size_t n, uint8_t *dst)
+{
+    memset(dst, 0, n);
+}
+
+static bool pem_read_privkey(FILE *fp, uint8_t **data, size_t size)
+{
+    uint8_t *buffer;
+    char *p;
+    size_t cap = ((DER_HEADER_SIZE + size) / 3) * 4 + 1 /*NUL*/;
+
+    buffer = malloc(cap);
+    if (!buffer)
+        return false;
+    p = (char *)buffer;
+
+    for (;;) {
+        char line[256], *nl;
+
+        if (fgets(line, sizeof(line), fp) == NULL)
+            break;
+        if (strspn(line, " \t\n") == strlen(line) ||
+            strstr(line, "-----BEGIN ") || strstr(line, "-----END "))
+            continue;
+
+        nl = strchr(line, '\n');
+        if (nl)
+            *nl = '\0';
+        p = stpcpy(p, line);
+    }
+
+    struct base64_decode_ctx decode;
+    size_t done;
+    base64_decode_init(&decode);
+    base64_decode_update(&decode, &done, buffer,
+                         strlen((char *)buffer), (const char *)buffer);
+    base64_decode_final(&decode);
+    if (done != DER_HEADER_SIZE + size) {
+        free(buffer);
+        return false;
+    }
+
+    memmove(buffer, buffer + (done - size), size);
+    *data = buffer;
+    return true;
+}
+
+int main(int argc, char *argv[]) {
+    int result = 1;
+    int r_ret;
+
+    size_t key_len = 0;
+    size_t msg_len = 0;
+    size_t sig_len = 0;
+
+    int mldsa_level = 65; /* default: ML-DSA-65 */
+    const char *alg_name;
+    sign_func *sign;
+
+    FILE *fp = NULL;
+
+    char *key_file_name = NULL, *in_file_name = NULL, *out_file_name = NULL, *time_file_name = NULL;
+    int in_fd = -1, out_fd = -1, time_fd = -1;
+
+    unsigned char *key = NULL;
+    unsigned char *msg = NULL;
+    unsigned char *sig = NULL;
+
+    int opt;
+    uint64_t time_diff;
+
+    while ((opt=getopt(argc, argv, "i:o:t:k:n:s:h")) != -1) {
+        switch (opt) {
+            case 'i': in_file_name = optarg; break;
+            case 'o': out_file_name = optarg; break;
+            case 't': time_file_name = optarg; break;
+            case 'k': key_file_name = optarg; break;
+            case 'n': sscanf(optarg, "%zu", &msg_len); break;
+            case 's': mldsa_level = atoi(optarg); break;
+            case 'h': help(argv[0]); return 0;
+            default:
+                fprintf(stderr, "Unknown option: %c\n", opt);
+                help(argv[0]);
+                return 1;
+        }
+    }
+
+    if (!in_file_name || !out_file_name || !time_file_name || !key_file_name || !msg_len) {
+        fprintf(stderr, "Missing parameters!\n");
+        help(argv[0]);
+        return 1;
+    }
+
+    if (mldsa_level != 65 && mldsa_level != 87) {
+        fprintf(stderr,
+                "Invalid ML-DSA parameter set: %d (use 65 or 87)\n",
+                mldsa_level);
+        return 1;
+    }
+
+    /* Open files */
+    in_fd = open(in_file_name, O_RDONLY);
+    if (in_fd == -1) {
+        fprintf(stderr, "can't open input file %s: %s\n", in_file_name, strerror(errno));
+        goto err;
+    }
+
+    out_fd = open(out_file_name, O_WRONLY|O_TRUNC|O_CREAT, 0666);
+    if (out_fd == -1){
+        fprintf(stderr, "can't open output file %s: %s\n", out_file_name, strerror(errno));
+        goto err;
+    }
+
+    time_fd = open(time_file_name, O_WRONLY|O_TRUNC|O_CREAT, 0666);
+    if (time_fd == -1){
+        fprintf(stderr, "can't open timing file %s: %s\n", time_file_name, strerror(errno));
+        goto err;
+    }
+
+    /* Allocate message buffer */
+    fprintf(stderr, "malloc(msg) - size %zu\n", msg_len);
+    msg = malloc(msg_len);
+    if (!msg)
+        goto err;
+
+    /* Signature algorithm */
+    switch (mldsa_level) {
+    case 65:
+        alg_name = "ML-DSA-65";
+        sign = ml_dsa_65_sign;
+        key_len = ML_DSA_65_PRIVATE_KEY_SIZE;
+        sig_len = ML_DSA_65_SIGNATURE_SIZE;
+        break;
+    case 87:
+        alg_name = "ML-DSA-87";
+        sign = ml_dsa_87_sign;
+        key_len = ML_DSA_87_PRIVATE_KEY_SIZE;
+        sig_len = ML_DSA_87_SIGNATURE_SIZE;
+        break;
+    default:
+        assert(0);
+        goto err;
+    }
+
+    /* Load key (PEM format) */
+    fp = fopen(key_file_name, "r");
+    if (!fp) {
+        fprintf(stderr, "can't open key file %s\n", key_file_name);
+        goto err;
+    }
+
+    if (!pem_read_privkey(fp, &key, key_len)) {
+        fprintf(stderr, "can't read key file %s\n", key_file_name);
+        goto err;
+    }
+
+    if (fclose(fp) != 0)
+        goto err;
+    fp = NULL;
+
+    fprintf(stderr, "Using %s\n", alg_name);
+    fprintf(stderr, "Signing messages...\n");
+
+    fprintf(stderr, "malloc(sig) - size %zu\n", sig_len);
+    sig = malloc(sig_len);
+    if (!sig)
+        goto err;
+
+    while((r_ret = read(in_fd, msg, msg_len)) > 0) {
+        if ((size_t)r_ret != msg_len) {
+            fprintf(stderr, "read less data than expected\n");
+            goto err;
+        }
+
+        sign(key,
+             msg_len, msg,
+             0 /*ctx_len*/, NULL /*ctx*/,
+             NULL /*random_ctx*/, random_zero /*random*/,
+             sig);
+        time_diff = nettle_ml_dsa_last_core_cycles;
+
+        if (write(time_fd, &time_diff, sizeof(time_diff)) != (ssize_t)sizeof(time_diff)) {
+            fprintf(stderr, "Write timing error\n");
+            goto err;
+        }
+
+        if (write(out_fd, sig, sig_len) != (ssize_t)sig_len) {
+            fprintf(stderr, "Write signature error\n");
+            goto err;
+        }
+    }
+
+    result = 0;
+    fprintf(stderr, "finished\n");
+    goto out;
+
+err:
+    fprintf(stderr, "failed!\n");
+    result = 1;
+
+out:
+    free(key);
+    free(msg);
+    free(sig);
+    if (in_fd >=0) close(in_fd);
+    if (out_fd >=0) close(out_fd);
+    if (time_fd >=0) close(time_fd);
+    if (fp) fclose(fp);
+
+    return result;
+}

--- a/openssl/timing_no_encode.c
+++ b/openssl/timing_no_encode.c
@@ -1,0 +1,234 @@
+#include <memory.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <errno.h>
+
+#include <openssl/err.h>
+#include <openssl/evp.h>
+#include <openssl/pem.h>
+#include <openssl/core_names.h>
+#include <openssl/params.h>
+#include <openssl/provider.h>
+
+extern uint64_t ossl_ml_dsa_last_core_cycles;
+
+static void help(const char *name) {
+    fprintf(stderr, "Usage: %s -i file -o file -t file -k file -n num [-h]\n", name);
+    fprintf(stderr, "\n");
+    fprintf(stderr, " -i file    File with concatenated messages to sign\n");
+    fprintf(stderr, " -o file    File where to write the signatures\n");
+    fprintf(stderr, " -t file    File where to write timing data\n");
+    fprintf(stderr, " -k file    File with the ML-DSA private key in PEM format\n");
+    fprintf(stderr, " -n num     Length of individual messages in bytes\n");
+    fprintf(stderr, " -s num     ML-DSA parameter set: 44, 65, or 87 (default: 44)\n");
+    fprintf(stderr, " -h         This message\n");
+}
+
+
+int main(int argc, char *argv[]) {
+    int result = 1;
+    int r_ret;
+
+    EVP_PKEY_CTX *ctx = NULL;
+    EVP_PKEY *pkey = NULL;
+    EVP_SIGNATURE *sig_alg = NULL;
+
+    size_t msg_len = 0;
+    size_t sig_len = 0;
+    size_t sig_cap = 0;
+
+    int mldsa_level = 44; /* default: ML-DSA-44 */
+
+    FILE *fp = NULL;
+
+    char *key_file_name = NULL, *in_file_name = NULL, *out_file_name = NULL, *time_file_name = NULL;
+    int in_fd = -1, out_fd = -1, time_fd = -1;
+
+    unsigned char *msg = NULL;
+    unsigned char *sig = NULL;
+
+    int opt;
+    uint64_t time_diff;
+
+    OSSL_PROVIDER *prov_default = NULL;
+
+    int deterministic = 1;
+    OSSL_PARAM params[] = {
+        OSSL_PARAM_construct_int(OSSL_SIGNATURE_PARAM_DETERMINISTIC, &deterministic),
+        OSSL_PARAM_END
+    };
+
+    while ((opt=getopt(argc, argv, "i:o:t:k:n:s:h")) != -1) {
+        switch (opt) {
+            case 'i': in_file_name = optarg; break;
+            case 'o': out_file_name = optarg; break;
+            case 't': time_file_name = optarg; break;
+            case 'k': key_file_name = optarg; break;
+            case 'n': sscanf(optarg, "%zu", &msg_len); break;
+            case 's': mldsa_level = atoi(optarg); break;
+            case 'h': help(argv[0]); return 0;
+            default:
+                fprintf(stderr, "Unknown option: %c\n", opt);
+                help(argv[0]);
+                return 1;
+        }
+    }
+
+    if (!in_file_name || !out_file_name || !time_file_name || !key_file_name || !msg_len) {
+        fprintf(stderr, "Missing parameters!\n");
+        help(argv[0]);
+        return 1;
+    }
+
+    if (mldsa_level != 44 && mldsa_level != 65 && mldsa_level != 87) {
+        fprintf(stderr,
+                "Invalid ML-DSA parameter set: %d (use 44, 65, or 87)\n",
+                mldsa_level);
+        return 1;
+    }    
+
+    /* Open files */
+    in_fd = open(in_file_name, O_RDONLY);
+    if (in_fd == -1) {
+        fprintf(stderr, "can't open input file %s: %s\n", in_file_name, strerror(errno));
+        goto err;
+    }
+
+    out_fd = open(out_file_name, O_WRONLY|O_TRUNC|O_CREAT, 0666);
+    if (out_fd == -1){
+        fprintf(stderr, "can't open output file %s: %s\n", out_file_name, strerror(errno));
+        goto err;
+    }
+
+    time_fd = open(time_file_name, O_WRONLY|O_TRUNC|O_CREAT, 0666);
+    if (time_fd == -1){
+        fprintf(stderr, "can't open timing file %s: %s\n", time_file_name, strerror(errno));
+        goto err;
+    }
+
+    prov_default = OSSL_PROVIDER_load(NULL, "default");
+    if (!prov_default) {
+        fprintf(stderr, "Failed to load default provider\n");
+        goto err;
+    }
+
+    /* Allocate message buffer */
+    fprintf(stderr, "malloc(msg) - size %zu\n", msg_len);
+    msg = malloc(msg_len);
+    if (!msg)
+        goto err;
+
+    /* Load key (PEM format) */
+    fp = fopen(key_file_name, "r");
+    if (!fp) {
+        fprintf(stderr, "can't open key file %s\n", key_file_name);
+        goto err;
+    }
+
+    if ((pkey = PEM_read_PrivateKey(fp, NULL, NULL, NULL)) == NULL)
+        goto err;
+
+    if (fclose(fp) != 0)
+        goto err;
+    fp = NULL;
+
+    /* Signature algorithm */
+
+    char alg_name[16];
+
+    snprintf(alg_name, sizeof(alg_name), "ML-DSA-%d", mldsa_level);
+    sig_alg = EVP_SIGNATURE_fetch(NULL, alg_name, NULL);
+    if (!sig_alg) {
+        fprintf(stderr, "EVP_SIGNATURE_fetch(%s) failed\n", alg_name);
+        goto err;
+    }
+
+    sig_cap = EVP_PKEY_get_size(pkey);
+    if (sig_cap == 0) {
+        fprintf(stderr, "EVP_PKEY_get_size() failed or returned 0\n");
+        goto err;
+    }
+
+    if (!EVP_PKEY_is_a(pkey, alg_name)) {
+        fprintf(stderr,
+                "Private key does not match selected algorithm (%s)\n",
+                alg_name);
+        goto err;
+    }
+
+    fprintf(stderr, "malloc(sig) - size %zu\n", sig_cap);
+    sig = malloc(sig_cap);
+    if (!sig)
+        goto err;
+
+    /* Create ctx */
+    ctx = EVP_PKEY_CTX_new_from_pkey(NULL, pkey, NULL);
+    if (!ctx)
+        goto err;
+
+    fprintf(stderr, "EVP_PKEY_sign_message_init(deterministic=1)\n");
+    if (EVP_PKEY_sign_message_init(ctx, sig_alg, params) <= 0)
+        goto err;
+
+    fprintf(stderr, "Using %s\n", alg_name);
+    fprintf(stderr, "Signing messages...\n");
+
+    while((r_ret = read(in_fd, msg, msg_len)) > 0) {
+        if ((size_t)r_ret != msg_len) {
+            fprintf(stderr, "read less data than expected\n");
+            goto err;
+        }
+
+        sig_len = sig_cap;
+
+        r_ret = EVP_PKEY_sign(ctx, sig, &sig_len, msg, msg_len); 
+        time_diff = ossl_ml_dsa_last_core_cycles;
+
+        if (r_ret <=0) {
+            fprintf(stderr, "Signing failure\n");
+        }
+
+        /* signature size check */
+        if (sig_len > sig_cap) {
+            fprintf(stderr, "Signature length overflow: %zu > %zu\n", sig_len, sig_cap);
+            goto err;
+        }
+
+        if (write(time_fd, &time_diff, sizeof(time_diff)) != (ssize_t)sizeof(time_diff)) {
+            fprintf(stderr, "Write timing error\n");
+            goto err;
+        }
+
+        if (write(out_fd, sig, sig_len) != (ssize_t)sig_len) {
+            fprintf(stderr, "Write signature error\n");
+            goto err;
+        }
+    }
+
+    result = 0;
+    fprintf(stderr, "finished\n");
+    goto out;
+
+err:
+    fprintf(stderr, "failed!\n");
+    ERR_print_errors_fp(stderr);
+    result = 1;
+
+out:
+    free(msg);
+    free(sig);
+    EVP_PKEY_CTX_free(ctx);
+    EVP_SIGNATURE_free(sig_alg);
+    EVP_PKEY_free(pkey);
+    if (in_fd >=0) close(in_fd);
+    if (out_fd >=0) close(out_fd);
+    if (time_fd >=0) close(time_fd);
+    if (fp) fclose(fp);
+    if (prov_default) OSSL_PROVIDER_unload(prov_default);
+
+    return result;
+}

--- a/scripts/create_folders.py
+++ b/scripts/create_folders.py
@@ -19,35 +19,39 @@ def main():
     print("Creating folders for CSV files")
 
     properties = (
-            'hw-rho-prime',
-            'bit-size-rho-prime',
-
-            'hw-y',
-            'bit-size-y',
-            'ntt-hw-y',
-            'ntt-bit-size-y',
-
-            'hw-w',
-            'bit-size-w',
-            'ntt-hw-w',
-            'ntt-bit-size-w',
-
-            'hw-c-s1',
-            'bit-size-c-s1',
-            'ntt-hw-c-s1',
-            'ntt-bit-size-c-s1',
-
-            'hw-c-s2',
-            'bit-size-c-s2',
-            'ntt-hw-c-s2',
-            'ntt-bit-size-c-s2',
-
-            'hw-w-cs2-low-bits',
-            'bit-size-w-cs2-low-bits',
-
-            'inf-norm-z',
-            'inf-norm-y',
-            'inf-norm-w0',
+        "hw-rho-prime",
+        "bit-size-rho-prime",
+        "rho-prime-n-zero",
+        "hw-y",
+        "bit-size-y",
+        "y-n-zero",
+        "y-n-need-reduction",
+        "y-n-fully-low-bit",
+        "y-n-above-low-bit-cutoff",
+        "ntt-hw-y",
+        "ntt-bit-size-y",
+        "hw-w",
+        "bit-size-w",
+        "w-n-zero",
+        "w-n-need-reduction",
+        "w-n-fully-low-bit",
+        "w-n-above-low-bit-cutoff",
+        "ntt-hw-w",
+        "ntt-bit-size-w",
+        "hw-c-s1",
+        "bit-size-c-s1",
+        "c-s1-n-zero",
+        "c-s1-n-need-reduction",
+        "ntt-hw-c-s1",
+        "ntt-bit-size-c-s1",
+        "hw-c-s2",
+        "bit-size-c-s2",
+        "c-s2-n-zero",
+        "c-s2-n-need-reduction",
+        "ntt-hw-c-s2",
+        "ntt-bit-size-c-s2",
+        "hw-w0",
+        "bit-size-w0",
         )
 
     for property in properties:


### PR DESCRIPTION
- Add new harnesses to measure ML-DSA signing time without signature encoding
- Extend extract.py with additional feature extraction:
  - number of zero coefficients
  - number of coefficients outside centered representation
  - additional derived metrics